### PR TITLE
Fix orogen gps base dep

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -16,6 +16,6 @@
   -->
   <depend package="base/types" />
   <depend package="drivers/imu_an_spatial" />
-  <depend package="drivers/gps_base" />
+  <depend package="drivers/orogen/gps_base" />
   <!--depend package="geographic" /-->
 </package>

--- a/manifest.xml
+++ b/manifest.xml
@@ -17,5 +17,5 @@
   <depend package="base/types" />
   <depend package="drivers/imu_an_spatial" />
   <depend package="drivers/orogen/gps_base" />
-  <!--depend package="geographic" /-->
+  <depend package="geographic" />
 </package>


### PR DESCRIPTION
@maltewi I know there is an ongoin [PR in the master repository](https://github.com/rock-drivers/drivers-orogen-imu_an_spatial/pull/2). I think these two dependencies should also be included in that PR. Without them the compilation is not successful anymore.